### PR TITLE
Add predictive calls for statistics/get

### DIFF
--- a/main.go
+++ b/main.go
@@ -143,6 +143,7 @@ func main() {
 	var noPatch = flag.Bool("no-patch", false, "Don't patch GGST with proxy address.")
 	var noClose = flag.Bool("no-close", false, "Don't automatically close totsugeki alongside GGST.")
 	var unsafeAsyncStatsSet = flag.Bool("unsafe-async-stats-set", false, "UNSAFE: Asynchronously upload stats (R-Code) in the background.")
+	var predictStatsGet = flag.Bool("predict-stats-get", false, "Asynchronously precache expected statistics/get calls.")
 	var iKnowWhatImDoing = flag.Bool("i-know-what-im-doing", false, "UNSAFE: Suppress any UNSAFE warnings. I hope you know what you're doing...")
 	var ver = flag.Bool("version", false, "Print the version number and exit.")
 
@@ -232,7 +233,10 @@ func main() {
 			}()
 			defer wg.Done()
 
-			server = proxy.CreateStriveProxy("127.0.0.1:21611", GGStriveAPIURL, PatchedAPIURL, &proxy.StriveAPIProxyOptions{AsyncStatsSet: *unsafeAsyncStatsSet})
+			server = proxy.CreateStriveProxy("127.0.0.1:21611", GGStriveAPIURL, PatchedAPIURL, &proxy.StriveAPIProxyOptions{
+				AsyncStatsSet:   *unsafeAsyncStatsSet,
+				PredictStatsGet: *predictStatsGet,
+			})
 
 			fmt.Println("Started Proxy Server on port 21611.")
 			err := server.Server.ListenAndServe()

--- a/main.go
+++ b/main.go
@@ -143,7 +143,7 @@ func main() {
 	var noPatch = flag.Bool("no-patch", false, "Don't patch GGST with proxy address.")
 	var noClose = flag.Bool("no-close", false, "Don't automatically close totsugeki alongside GGST.")
 	var unsafeAsyncStatsSet = flag.Bool("unsafe-async-stats-set", false, "UNSAFE: Asynchronously upload stats (R-Code) in the background.")
-	var unsafePredictStatsGet = flag.Bool("unsafe-predict-stats-get", false, "Asynchronously precache expected statistics/get calls.")
+	var unsafePredictStatsGet = flag.Bool("unsafe-predict-stats-get", false, "UNSAFE: Asynchronously precache expected statistics/get calls.")
 	var iKnowWhatImDoing = flag.Bool("i-know-what-im-doing", false, "UNSAFE: Suppress any UNSAFE warnings. I hope you know what you're doing...")
 	var ver = flag.Bool("version", false, "Print the version number and exit.")
 

--- a/main.go
+++ b/main.go
@@ -143,7 +143,7 @@ func main() {
 	var noPatch = flag.Bool("no-patch", false, "Don't patch GGST with proxy address.")
 	var noClose = flag.Bool("no-close", false, "Don't automatically close totsugeki alongside GGST.")
 	var unsafeAsyncStatsSet = flag.Bool("unsafe-async-stats-set", false, "UNSAFE: Asynchronously upload stats (R-Code) in the background.")
-	var predictStatsGet = flag.Bool("predict-stats-get", false, "Asynchronously precache expected statistics/get calls.")
+	var unsafePredictStatsGet = flag.Bool("unsafe-predict-stats-get", false, "Asynchronously precache expected statistics/get calls.")
 	var iKnowWhatImDoing = flag.Bool("i-know-what-im-doing", false, "UNSAFE: Suppress any UNSAFE warnings. I hope you know what you're doing...")
 	var ver = flag.Bool("version", false, "Print the version number and exit.")
 
@@ -235,7 +235,7 @@ func main() {
 
 			server = proxy.CreateStriveProxy("127.0.0.1:21611", GGStriveAPIURL, PatchedAPIURL, &proxy.StriveAPIProxyOptions{
 				AsyncStatsSet:   *unsafeAsyncStatsSet,
-				PredictStatsGet: *predictStatsGet,
+				PredictStatsGet: *unsafePredictStatsGet,
 			})
 
 			fmt.Println("Started Proxy Server on port 21611.")
@@ -248,7 +248,7 @@ func main() {
 		}()
 	}
 
-	if !*iKnowWhatImDoing && (*unsafeAsyncStatsSet) {
+	if !*iKnowWhatImDoing && (*unsafeAsyncStatsSet || *unsafePredictStatsGet) {
 		fmt.Println("WARNING: Unsafe feature used. Make sure you understand the implications: https://github.com/optix2000/totsugeki/blob/master/UNSAFE_FEATURES.md")
 	}
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -109,7 +109,7 @@ func CreateStriveProxy(listen string, GGStriveAPIURL string, PatchedAPIURL strin
 			ResponseHeaderTimeout: 1 * time.Minute, // Some people have _really_ slow internet to Japan.
 			MaxIdleConns:          2,
 			MaxIdleConnsPerHost:   1,
-			MaxConnsPerHost:       6,
+			MaxConnsPerHost:       5,
 			IdleConnTimeout:       90 * time.Second, // Drop idle connection after 90 seconds to balance between being nice to ASW and keeping things fast.
 			TLSHandshakeTimeout:   30 * time.Second,
 		},

--- a/proxy/stats_get_prediction.go
+++ b/proxy/stats_get_prediction.go
@@ -209,7 +209,6 @@ func (s *StatsGetPrediction) ProcessStatsQueue(queue chan *StatsGetTask) {
 			req.RequestURI = ""
 			res, err := client.Do(req)
 
-			//res, err := s.proxyRequest(req)
 			if err != nil {
 				fmt.Print("Res error: ")
 				fmt.Println(err)

--- a/proxy/stats_get_prediction.go
+++ b/proxy/stats_get_prediction.go
@@ -1,0 +1,346 @@
+package proxy
+
+// Precaches statistics/get calls if the opening sequence of calls is detected
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+const StatsGetWorkers = 5
+
+type StatsGetTask struct {
+	request  string
+	response chan *http.Response
+}
+
+type StatsGetPrediction struct {
+	enable         bool
+	GGStriveAPIURL string
+	loginPrefix    string
+	// TODO: Improve this.
+	// Counts up for env->login->stats/get, to kick off Async StatsGet predictive cache
+	statsGetPredictionCounter int
+	statsGetTasks             map[string]*StatsGetTask
+}
+
+func (s *StatsGetPrediction) HandleCatchallPath(path string) {
+	if !s.enable {
+		return
+	}
+	if s.statsGetPredictionCounter > 0 && path != "/statistics/get" {
+		fmt.Println("Done looking up stats")
+		s.statsGetPredictionCounter = 0
+	}
+}
+
+func (s *StatsGetPrediction) HandleGetEnv() {
+	if !s.enable {
+		return
+	}
+	s.statsGetPredictionCounter = 1
+}
+
+func (s *StatsGetPrediction) HandleLoginData(login []byte) {
+	if !s.enable {
+		return
+	}
+	if s.statsGetPredictionCounter == 1 {
+		s.statsGetPredictionCounter = 2
+		s.ParseLoginPrefix(login)
+	}
+}
+
+// Proxy getstats
+func (s *StatsGetPrediction) HandleGetStats(w http.ResponseWriter, r *http.Request) bool {
+	if !s.enable {
+		return false
+	}
+	if len(s.loginPrefix) > 0 && s.statsGetPredictionCounter == 2 {
+		s.AsyncGetStats()
+		s.statsGetPredictionCounter = 3
+	}
+	if len(s.loginPrefix) > 0 && s.statsGetPredictionCounter == 3 {
+		bodyBytes, _ := ioutil.ReadAll(r.Body)
+		r.Body.Close() //  must close
+		r.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
+		req := string(bodyBytes)
+		if task, ok := s.statsGetTasks[req]; ok {
+			resp := <-task.response
+			if resp == nil {
+				fmt.Println("Cache Error!")
+				delete(s.statsGetTasks, req)
+				return false
+			}
+			defer resp.Body.Close()
+			// Copy headers
+			for name, values := range resp.Header {
+				w.Header()[name] = values
+			}
+			w.WriteHeader(resp.StatusCode)
+			reader := io.TeeReader(resp.Body, w) // For dumping API payloads
+			_, err := io.ReadAll(reader)
+			if err != nil {
+				fmt.Println(err)
+			}
+			delete(s.statsGetTasks, req)
+			return true
+		}
+		fmt.Println("Cache miss! " + req)
+		return false
+
+	}
+	return false
+}
+
+func (s *StatsGetPrediction) ParseLoginPrefix(loginRet []byte) {
+	s.loginPrefix = hex.EncodeToString(loginRet[60:79]) + hex.EncodeToString(loginRet[2:16])
+}
+
+func (s *StatsGetPrediction) BuildStatsReqBody(login string, req string) string {
+	/*
+
+		Get Stats Call Analysis
+		E.g.
+		data=9295xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx02a5302e302e350396a007ffffffff^@
+
+		1.
+		"data="
+		length=5
+
+		2. Header?
+		9295
+		length=2
+
+
+		3. Login 1?
+		index in login response=60
+		length=19
+
+		4. Login 2?
+		index in login response=2
+		length=14
+
+		5. Divider?
+		02a5
+		l=2
+
+		6. Version?
+		302e302e35 (0.0.5)
+		l=5
+
+		7. Divider2?
+		0396
+		l=2
+
+		8. Specific call
+		e.g. a007ffffffff , Confirm that this stays between users
+		l=6
+
+
+		9=End
+		\0
+		l=1
+	*/
+
+	body := "data=" +
+		"9295" + // Header
+		login +
+		"02a5" + // Divider
+		"302e302e35" + // 0.0.5
+		"0396" + // Divider 2
+		req +
+		"\x00" // End
+
+	return body
+}
+
+func (s *StatsGetPrediction) ProcessStatsQueue(queue chan *StatsGetTask) {
+	client := http.Client{
+		Transport: &http.Transport{
+			Proxy:                 http.ProxyFromEnvironment,
+			DialContext:           (&net.Dialer{Timeout: 30 * time.Second}).DialContext,
+			ResponseHeaderTimeout: 1 * time.Minute, // Some people have _really_ slow internet to Japan.
+			MaxIdleConns:          2,
+			MaxIdleConnsPerHost:   1,
+			MaxConnsPerHost:       2,
+			IdleConnTimeout:       90 * time.Second, // Drop idle connection after 90 seconds to balance between being nice to ASW and keeping things fast.
+			TLSHandshakeTimeout:   30 * time.Second,
+		},
+		Timeout: 3 * time.Minute, // 2x the slowest request I've seen.
+	}
+
+	for {
+		select {
+		case item := <-queue:
+			reqBytes := bytes.NewBuffer([]byte(item.request))
+			req, err := http.NewRequest("POST", s.GGStriveAPIURL+"statistics/get", reqBytes)
+			if err != nil {
+				fmt.Print("Req error: ")
+				fmt.Println(err)
+				item.response <- nil
+				continue
+			}
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			req.Header.Set("Cache-Control", "no-cache")
+			req.Header.Set("Cookie", "theme=theme-dark")
+			req.Header.Set("User-Agent", "Steam")
+			req.Header.Set("Content-Length", strconv.Itoa(len(item.request)))
+
+			apiURL, err := url.Parse(s.GGStriveAPIURL) // TODO: Const this
+			if err != nil {
+				fmt.Print("Url error: ")
+				fmt.Println(err)
+				item.response <- nil
+				continue
+			}
+			apiURL.Path = req.URL.Path
+
+			req.URL = apiURL
+			req.Host = ""
+			req.RequestURI = ""
+			res, err := client.Do(req)
+
+			//res, err := s.proxyRequest(req)
+			if err != nil {
+				fmt.Print("Res error: ")
+				fmt.Println(err)
+				item.response <- nil
+			} else {
+				item.response <- res
+			}
+		default:
+			fmt.Println("Empty queue, shutting down")
+			return
+
+		}
+	}
+
+}
+
+func (s *StatsGetPrediction) AsyncGetStats() {
+	reqs := s.ExpectedStatsGetCalls()
+
+	queue := make(chan *StatsGetTask, len(reqs)+1)
+	for _, val := range reqs {
+		id := s.BuildStatsReqBody(s.loginPrefix, val)
+		task := &StatsGetTask{id, make(chan *http.Response)}
+
+		s.statsGetTasks[id] = task
+		queue <- task
+	}
+
+	for i := 0; i < StatsGetWorkers; i++ {
+		go s.ProcessStatsQueue(queue)
+	}
+}
+func CreateStatsGetPrediction(enabled bool, GGStriveAPIURL string) StatsGetPrediction {
+	return StatsGetPrediction{
+		enable:                    enabled,
+		GGStriveAPIURL:            GGStriveAPIURL,
+		loginPrefix:               "",
+		statsGetPredictionCounter: 0,
+		statsGetTasks:             make(map[string]*StatsGetTask),
+	}
+}
+
+func (s *StatsGetPrediction) ExpectedStatsGetCalls() []string {
+	return []string{
+		"a007ffffffff",
+		"a009ffffffff",
+		"a008ff00ffff",
+		"a008ff01ffff",
+		"a008ff02ffff",
+		"a008ff03ffff",
+		"a008ff04ffff",
+		"a008ff05ffff",
+		"a008ff06ffff",
+		"a008ff07ffff",
+		"a008ff08ffff",
+		"a008ff09ffff",
+		"a008ff0affff",
+		"a008ff0bffff",
+		"a008ff0cffff",
+		"a008ff0dffff",
+		"a008ff0effff",
+		"a008ff0fffff",
+		"a008ffffffff",
+		"a006ff00ffff",
+		"a006ff01ffff",
+		"a006ff02ffff",
+		"a006ff03ffff",
+		"a006ff04ffff",
+		"a006ff05ffff",
+		"a006ff06ffff",
+		"a006ff07ffff",
+		"a006ff08ffff",
+		"a006ff09ffff",
+		"a006ff0affff",
+		"a006ff0bffff",
+		"a006ff0cffff",
+		"a006ff0dffff",
+		"a006ff0effff",
+		"a006ff0fffff",
+		"a006ffffffff",
+		"a005ffffffff",
+		"a0020100ffff",
+		"a0020101ffff",
+		"a0020102ffff",
+		"a0020103ffff",
+		"a0020104ffff",
+		"a0020105ffff",
+		"a0020106ffff",
+		"a0020107ffff",
+		"a0020108ffff",
+		"a0020109ffff",
+		"a002010affff",
+		"a002010bffff",
+		"a002010cffff",
+		"a002010dffff",
+		"a002010effff",
+		"a002010fffff",
+		"a00201ffffff",
+		"a0010100feff",
+		"a0010100ffff",
+		"a0010101feff",
+		"a0010101ffff",
+		"a0010102feff",
+		"a0010102ffff",
+		"a0010103feff",
+		"a0010103ffff",
+		"a0010104feff",
+		"a0010104ffff",
+		"a0010105feff",
+		"a0010105ffff",
+		"a0010106feff",
+		"a0010106ffff",
+		"a0010107feff",
+		"a0010107ffff",
+		"a0010108feff",
+		"a0010108ffff",
+		"a0010109feff",
+		"a0010109ffff",
+		"a001010afeff",
+		"a001010affff",
+		"a001010bfeff",
+		"a001010bffff",
+		"a001010cfeff",
+		"a001010cffff",
+		"a001010dfeff",
+		"a001010dffff",
+		"a001010efeff",
+		"a001010effff",
+		"a001010ffeff",
+		"a001010fffff",
+		"a00101fffeff",
+		"a00101ffffff",
+	}
+}

--- a/proxy/stats_get_prediction.go
+++ b/proxy/stats_get_prediction.go
@@ -10,7 +10,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"strconv"
+	"strings"
 )
 
 const StatsGetWorkers = 5
@@ -181,18 +181,19 @@ func (s *StatsGetPrediction) BuildStatsReqBody(login string, req string) string 
 		l=1
 	*/
 
-	body := "data=" +
-		"9295" + // Header
-		login +
-		"02a5" + // Divider
-		"302e302e35" + // 0.0.5
-		"0396" + // Divider 2
-		req +
-		"\x00" // End
-
-	return body
+	var sb strings.Builder
+	sb.WriteString("data=")
+	sb.WriteString("9295") // Header
+	sb.WriteString(login)
+	sb.WriteString("02a5")       // Divider
+	sb.WriteString("302e302e35") // 0.0.5
+	sb.WriteString("0396")       // Divider 2
+	sb.WriteString(req)
+	sb.WriteString("\x00") // End
+	return sb.String()
 }
 
+// Process the filled queue, then exit when it's empty
 func (s *StatsGetPrediction) ProcessStatsQueue(queue chan *StatsGetTask) {
 	for {
 		select {
@@ -209,7 +210,6 @@ func (s *StatsGetPrediction) ProcessStatsQueue(queue chan *StatsGetTask) {
 			req.Header.Set("Cache-Control", "no-cache")
 			req.Header.Set("Cookie", "theme=theme-dark")
 			req.Header.Set("User-Agent", "Steam")
-			req.Header.Set("Content-Length", strconv.Itoa(len(item.request)))
 
 			apiURL, err := url.Parse(s.GGStriveAPIURL) // TODO: Const this
 			if err != nil {


### PR DESCRIPTION
Constructs and asynchronously precaches the expected statistics/get calls.
I haven't tested on any other account yet, so I can't guarantee its portability. The code's a bit of a mess, sorry I don't have much experience with Go.

Cuts the 88 calls down from ~19s to ~7s : 

2021/08/08 19:44:49 "POST http://127.0.0.1:21611/api/sys/get_env HTTP/1.1" from 127.0.0.1:56205 - 200 88B in 750.5014ms
2021/08/08 19:44:49 "POST http://127.0.0.1:21611/api/user/login HTTP/1.1" from 127.0.0.1:56207 - 200 122B in 204.6694ms
2021/08/08 19:44:50 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 4390B in 783.4534ms
2021/08/08 19:44:50 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 724B in 0s
2021/08/08 19:44:50 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 2282B in 824.6µs
2021/08/08 19:44:50 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 2282B in 896.1µs
2021/08/08 19:44:50 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 2282B in 0s
2021/08/08 19:44:50 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 2282B in 0s
2021/08/08 19:44:50 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 2282B in 0s
2021/08/08 19:44:50 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 2282B in 0s
2021/08/08 19:44:50 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 2282B in 0s
2021/08/08 19:44:50 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 2282B in 0s
2021/08/08 19:44:51 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 2282B in 0s
2021/08/08 19:44:51 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 2282B in 0s
2021/08/08 19:44:51 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 2282B in 0s
2021/08/08 19:44:51 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 2282B in 0s
2021/08/08 19:44:51 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 2282B in 930.9µs
2021/08/08 19:44:51 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 2282B in 0s
2021/08/08 19:44:51 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 2282B in 0s
2021/08/08 19:44:51 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 2282B in 0s
2021/08/08 19:44:51 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 2282B in 0s
2021/08/08 19:44:51 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 26953B in 0s
2021/08/08 19:44:51 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 26817B in 425.7µs
2021/08/08 19:44:51 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 26794B in 825.5µs
2021/08/08 19:44:52 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 26794B in 1.0008ms
2021/08/08 19:44:52 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 26797B in 351.9µs
2021/08/08 19:44:52 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 26794B in 214.3µs
2021/08/08 19:44:52 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 26794B in 515.5µs
2021/08/08 19:44:52 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 26794B in 0s
2021/08/08 19:44:52 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 26794B in 1.0005ms
2021/08/08 19:44:52 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 26794B in 0s
2021/08/08 19:44:52 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 26794B in 801.4µs
2021/08/08 19:44:52 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 26794B in 859.4µs
2021/08/08 19:44:52 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 26794B in 0s
2021/08/08 19:44:52 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 26794B in 98.2µs
2021/08/08 19:44:52 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 26794B in 0s
2021/08/08 19:44:53 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 0s
2021/08/08 19:44:53 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 26979B in 0s
2021/08/08 19:44:53 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 7913B in 0s
2021/08/08 19:44:53 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 356B in 0s
2021/08/08 19:44:53 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 0s
2021/08/08 19:44:53 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 0s
2021/08/08 19:44:53 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 0s
2021/08/08 19:44:53 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 0s
2021/08/08 19:44:53 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 0s
2021/08/08 19:44:53 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 0s
2021/08/08 19:44:53 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 227.8µs
2021/08/08 19:44:53 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 850.7µs
2021/08/08 19:44:54 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 0s
2021/08/08 19:44:54 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 374.4µs
2021/08/08 19:44:54 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 281.3µs
2021/08/08 19:44:54 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 0s
2021/08/08 19:44:54 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 0s
2021/08/08 19:44:54 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 821.8µs
2021/08/08 19:44:54 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 0s
2021/08/08 19:44:54 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 356B in 132.5µs
2021/08/08 19:44:54 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 11209B in 813.3µs
2021/08/08 19:44:54 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 3794B in 0s
2021/08/08 19:44:54 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 0s
2021/08/08 19:44:54 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 0s
2021/08/08 19:44:55 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 0s
2021/08/08 19:44:55 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 1ms
2021/08/08 19:44:55 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 0s
2021/08/08 19:44:55 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 0s
2021/08/08 19:44:55 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 374.9µs
2021/08/08 19:44:55 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 0s
2021/08/08 19:44:55 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 0s
2021/08/08 19:44:55 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 0s
2021/08/08 19:44:55 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 0s
2021/08/08 19:44:55 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 0s
2021/08/08 19:44:55 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 0s
2021/08/08 19:44:55 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 0s
2021/08/08 19:44:56 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 0s
2021/08/08 19:44:56 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 0s
2021/08/08 19:44:56 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 0s
2021/08/08 19:44:56 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 0s
2021/08/08 19:44:56 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 0s
2021/08/08 19:44:56 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 615.2µs
2021/08/08 19:44:56 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 0s
2021/08/08 19:44:56 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 186.6µs
2021/08/08 19:44:56 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 264.5µs
2021/08/08 19:44:56 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 0s
2021/08/08 19:44:56 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 363.3µs
2021/08/08 19:44:56 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 820.7µs
2021/08/08 19:44:57 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 0s
Empty queue, shutting down
2021/08/08 19:44:57 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 81.6µs
Empty queue, shutting down
2021/08/08 19:44:57 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 807.7µs
Empty queue, shutting down
2021/08/08 19:44:57 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 62B in 0s
Empty queue, shutting down
2021/08/08 19:44:57 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 11209B in 634.5µs
Empty queue, shutting down
2021/08/08 19:44:57 "POST http://127.0.0.1:21611/api/statistics/get HTTP/1.1" from 127.0.0.1:56207 - 200 3794B in 307.7µs
Done looking up stats
2021/08/08 19:44:58 "POST http://127.0.0.1:21611/api/statistics/set HTTP/1.1" from 127.0.0.1:56207 - 200 59B in 214.5103ms
2021/08/08 19:44:58 "POST http://127.0.0.1:21611/api/statistics/set HTTP/1.1" from 127.0.0.1:56207 - 200 59B in 626.0845ms
2021/08/08 19:44:59 "POST http://127.0.0.1:21611/api/statistics/set HTTP/1.1" from 127.0.0.1:56207 - 200 59B in 357.2075ms
2021/08/08 19:44:59 "POST http://127.0.0.1:21611/api/statistics/set HTTP/1.1" from 127.0.0.1:56207 - 200 59B in 462.8115ms
2021/08/08 19:45:00 "POST http://127.0.0.1:21611/api/statistics/set HTTP/1.1" from 127.0.0.1:56207 - 200 59B in 433.6656ms
2021/08/08 19:45:00 "POST http://127.0.0.1:21611/api/statistics/set HTTP/1.1" from 127.0.0.1:56207 - 200 59B in 442.131ms
2021/08/08 19:45:01 "POST http://127.0.0.1:21611/api/statistics/set HTTP/1.1" from 127.0.0.1:56207 - 200 59B in 493.572ms
2021/08/08 19:45:01 "POST http://127.0.0.1:21611/api/statistics/set HTTP/1.1" from 127.0.0.1:56207 - 200 59B in 447.8864ms
2021/08/08 19:45:02 "POST http://127.0.0.1:21611/api/statistics/set HTTP/1.1" from 127.0.0.1:56207 - 200 59B in 396.5558ms
2021/08/08 19:45:02 "POST http://127.0.0.1:21611/api/statistics/set HTTP/1.1" from 127.0.0.1:56207 - 200 59B in 405.9449ms
2021/08/08 19:45:02 "POST http://127.0.0.1:21611/api/statistics/set HTTP/1.1" from 127.0.0.1:56207 - 200 59B in 380.7232ms
2021/08/08 19:45:03 "POST http://127.0.0.1:21611/api/statistics/set HTTP/1.1" from 127.0.0.1:56207 - 200 59B in 370.216ms
2021/08/08 19:45:03 "POST http://127.0.0.1:21611/api/statistics/set HTTP/1.1" from 127.0.0.1:56207 - 200 59B in 419.268ms
2021/08/08 19:45:04 "POST http://127.0.0.1:21611/api/statistics/set HTTP/1.1" from 127.0.0.1:56207 - 200 59B in 352.4136ms
2021/08/08 19:45:04 "POST http://127.0.0.1:21611/api/statistics/set HTTP/1.1" from 127.0.0.1:56207 - 200 59B in 442.2107ms
2021/08/08 19:45:05 "POST http://127.0.0.1:21611/api/statistics/set HTTP/1.1" from 127.0.0.1:56207 - 200 59B in 370.9468ms
2021/08/08 19:45:06 "POST http://127.0.0.1:21611/api/tus/write HTTP/1.1" from 127.0.0.1:56207 - 200 59B in 924.0961ms
2021/08/08 19:45:06 "POST http://127.0.0.1:21611/api/catalog/get_follow HTTP/1.1" from 127.0.0.1:56207 - 200 63B in 188.0536ms
2021/08/08 19:45:06 "POST http://127.0.0.1:21611/api/catalog/get_block HTTP/1.1" from 127.0.0.1:56207 - 200 63B in 180.5847ms
2021/08/08 19:45:06 "POST http://127.0.0.1:21611/api/catalog/get_replay HTTP/1.1" from 127.0.0.1:56207 - 200 898B in 232.0526ms
2021/08/08 19:45:06 "POST http://127.0.0.1:21611/api/catalog/get_replay HTTP/1.1" from 127.0.0.1:56207 - 200 898B in 235.0867ms
2021/08/08 19:45:07 "POST http://127.0.0.1:21611/api/catalog/get_replay HTTP/1.1" from 127.0.0.1:56207 - 200 932B in 187.2807ms
2021/08/08 19:45:07 "POST http://127.0.0.1:21611/api/lobby/get_vip_status HTTP/1.1" from 127.0.0.1:56207 - 200 61B in 223.561ms
2021/08/08 19:45:08 "POST http://127.0.0.1:21611/api/item/get_item HTTP/1.1" from 127.0.0.1:56207 - 200 61B in 228.0793ms
2021/08/08 19:45:08 "POST http://127.0.0.1:21611/api/statistics/set HTTP/1.1" from 127.0.0.1:56207 - 200 59B in 233.6574ms
2021/08/08 19:45:08 "POST http://127.0.0.1:21611/api/statistics/set HTTP/1.1" from 127.0.0.1:56207 - 200 59B in 200.1365ms
2021/08/08 19:45:08 "POST http://127.0.0.1:21611/api/statistics/set HTTP/1.1" from 127.0.0.1:56207 - 200 59B in 209.0975ms
2021/08/08 19:45:09 "POST http://127.0.0.1:21611/api/statistics/set HTTP/1.1" from 127.0.0.1:56207 - 200 59B in 231.5874ms
2021/08/08 19:45:09 "POST http://127.0.0.1:21611/api/statistics/set HTTP/1.1" from 127.0.0.1:56207 - 200 59B in 237.855ms
2021/08/08 19:45:09 "POST http://127.0.0.1:21611/api/statistics/set HTTP/1.1" from 127.0.0.1:56207 - 200 59B in 184.1354ms
2021/08/08 19:45:09 "POST http://127.0.0.1:21611/api/statistics/set HTTP/1.1" from 127.0.0.1:56207 - 200 59B in 233.2095ms
2021/08/08 19:45:10 "POST http://127.0.0.1:21611/api/statistics/set HTTP/1.1" from 127.0.0.1:56207 - 200 59B in 228.1558ms
2021/08/08 19:45:10 "POST http://127.0.0.1:21611/api/statistics/set HTTP/1.1" from 127.0.0.1:56207 - 200 59B in 203.5506ms
2021/08/08 19:45:10 "POST http://127.0.0.1:21611/api/statistics/set HTTP/1.1" from 127.0.0.1:56207 - 200 59B in 273.6371ms
2021/08/08 19:45:10 "POST http://127.0.0.1:21611/api/statistics/set HTTP/1.1" from 127.0.0.1:56207 - 200 59B in 202.4744ms
2021/08/08 19:45:11 "POST http://127.0.0.1:21611/api/statistics/set HTTP/1.1" from 127.0.0.1:56207 - 200 59B in 206.0463ms
2021/08/08 19:45:11 "POST http://127.0.0.1:21611/api/statistics/set HTTP/1.1" from 127.0.0.1:56207 - 200 59B in 230.4112ms
2021/08/08 19:45:11 "POST http://127.0.0.1:21611/api/statistics/set HTTP/1.1" from 127.0.0.1:56207 - 200 59B in 196.7701ms
2021/08/08 19:45:11 "POST http://127.0.0.1:21611/api/statistics/set HTTP/1.1" from 127.0.0.1:56207 - 200 59B in 241.7007ms
2021/08/08 19:45:14 "POST http://127.0.0.1:21611/api/sys/get_news HTTP/1.1" from 127.0.0.1:56207 - 200 741900B in 1.3231453s
