### PR TITLE
new memory offset for 1.09

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ var UngaBungaMode string = ""
 
 const GGStriveExe = "GGST-Win64-Shipping.exe"
 
-const APIOffsetAddr uintptr = 0x342AD10 // 1.07
+const APIOffsetAddr uintptr = 0x33EE420 // 1.09
 
 const GGStriveAPIURL = "https://ggst-game.guiltygear.com/api/"
 const PatchedAPIURL = "http://127.0.0.1:21611/api/"


### PR DESCRIPTION
Memory address offset is wrong after update to game version 1.09.  
Should fix #38 