### PR TITLE
add new finished state to stats get prediction

### DIFF
--- a/proxy/stats_get_prediction.go
+++ b/proxy/stats_get_prediction.go
@@ -39,6 +39,7 @@ const (
 	get_env_called
 	login_parsed
 	sending_calls
+	finished
 )
 
 type CachingResponseWriter struct {
@@ -64,15 +65,14 @@ func (rw *CachingResponseWriter) Write(data []byte) (int, error) {
 func (s *StatsGetPrediction) StatsGetStateHandler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
-		if s.predictionState != reset &&
-			path == "/api/sys/get_news" {
+		if s.predictionState != finished && path == "/api/sys/get_news" {
 			if s.predictionState == sending_calls {
 				fmt.Println("Done looking up stats")
 			}
-			s.predictionState = reset
+			s.predictionState = finished
 		}
 
-		if path == "/api/sys/get_env" || path == "/api/user/login" {
+		if (path == "/api/sys/get_env" || path == "/api/user/login") && s.predictionState != finished {
 			wrappedWriter := CachingResponseWriter{w: w}
 			next.ServeHTTP(&wrappedWriter, r)
 


### PR DESCRIPTION
This should fix #50.

Some online features in GGST trigger new /get_env and /login calls, making stats_get_prediction think it's doing the initial title screen loading again. Totsugeki gets stuck at this point and other requests by GGST time out.
I added a new `finished` state so that the stats_get_prediction doesn't get started again. If you go back to the title screen from the main menu and then do the loading screen again the /statistics/get requests are not used, so we can skip this step without affecting load times.