### PR TITLE
rework stats_get_prediction to work with r-code, better reset

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -27,6 +27,14 @@
         "mode": "auto",
         "program": "${workspaceFolder}/main.go",
         "args": ["-unsafe-cache-news"]
+    },
+    {
+        "name": "Launch No-Close",
+        "type": "go",
+        "request": "launch",
+        "mode": "auto",
+        "program": "${workspaceFolder}/main.go",
+        "args": ["-unga-bunga", "-no-close"]
     }
     ]
 }

--- a/main.go
+++ b/main.go
@@ -179,10 +179,6 @@ func watchGGST(noClose bool, ctx context.Context) {
 					if !noClose {
 						close = true
 					}
-					// Reset stats_get_prediction state so it gets used again on 2nd+ start of GGST
-					if server != nil {
-						server.ResetStatsGetPrediction()
-					}
 					break
 				}
 			}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -134,10 +134,6 @@ func (s *StriveAPIProxy) Shutdown() {
 	s.wg.Wait()
 }
 
-func (s *StriveAPIProxy) ResetStatsGetPrediction() {
-	s.prediction.predictionState = reset
-}
-
 func CreateStriveProxy(listen string, GGStriveAPIURL string, PatchedAPIURL string, options *StriveAPIProxyOptions) *StriveAPIProxy {
 
 	transport := http.Transport{


### PR DESCRIPTION
I still have no idea what I'm doing in Go, but here's my attempt to rework the stats_get_prediction code:
- I removed the reset on process patch that I added last PR.
- Prediction now resets on `/api/tus/read` call. This one seems to get called after the title screen load an r-code loads so it should be save to reset here.
- R-Code prediction is slightly different. It's missing some of the requests that the title screen is doing, and the body is longer. Instead of generating the body I'm just copying the body of the first request and replacing the last bytes that are different. (We could probably do the same for the title screen requests. Would remove the need to parse api version and login token to build request.)

Should fix: #55  (last comment by fefo-dev)