### PR TITLE
More login speedups

### DIFF
--- a/main.go
+++ b/main.go
@@ -283,6 +283,7 @@ func main() {
 	var unsafePredictStatsGet = flag.Bool("unsafe-predict-stats-get", false, "UNSAFE: Asynchronously precache expected statistics/get calls.")
 	var unsafeCacheNews = flag.Bool("unsafe-cache-news", false, "UNSAFE: Cache first news call and return cached version on subsequent calls.")
 	var unsafeNoNews = flag.Bool("unsafe-no-news", false, "UNSAFE: Return an empty response for news.")
+	var unsafeCacheEnv = flag.Bool("unsafe-cache-env", false, "UNSAFE: Cache first get_env call and return cached version on subsequent calls.")
 	var ungaBunga = flag.Bool("unga-bunga", UngaBungaMode != "", "UNSAFE: Enable all unsafe speedups for maximum speed. Please read https://github.com/optix2000/totsugeki/blob/master/UNSAFE_SPEEDUPS.md")
 	var iKnowWhatImDoing = flag.Bool("i-know-what-im-doing", false, "UNSAFE: Suppress any UNSAFE warnings. I hope you know what you're doing...")
 	var ver = flag.Bool("version", false, "Print the version number and exit.")
@@ -323,6 +324,7 @@ func main() {
 		*unsafeAsyncStatsSet = true
 		*unsafePredictStatsGet = true
 		*unsafeNoNews = true
+		*unsafeCacheEnv = true
 	}
 
 	// Drop process priority
@@ -399,6 +401,7 @@ func main() {
 				PredictStatsGet: *unsafePredictStatsGet,
 				CacheNews:       *unsafeCacheNews,
 				NoNews:          *unsafeNoNews,
+				CacheEnv:        *unsafeCacheEnv,
 			})
 
 			fmt.Println("Started Proxy Server on port 21611.")
@@ -411,7 +414,7 @@ func main() {
 		}()
 	}
 
-	if !*iKnowWhatImDoing && (*unsafeAsyncStatsSet || *unsafePredictStatsGet || *unsafeCacheNews || *unsafeNoNews) {
+	if !*iKnowWhatImDoing && (*unsafeAsyncStatsSet || *unsafePredictStatsGet || *unsafeCacheNews || *unsafeNoNews || *unsafeCacheEnv) {
 		fmt.Println("WARNING: Unsafe feature used. Make sure you understand the implications: https://github.com/optix2000/totsugeki/blob/master/UNSAFE_SPEEDUPS.md")
 	}
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -189,6 +189,11 @@ func CreateStriveProxy(listen string, GGStriveAPIURL string, PatchedAPIURL strin
 		getNews = proxy.HandleGetNews
 	}
 
+	// Make a random request to initialize TLS connection
+	resp, _ := client.Post(GGStriveAPIURL+"sys/get_env", "application/x-www-form-urlencoded", bytes.NewBuffer([]byte("data=9295a0a002a5302e302e360391cd0100")))
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+
 	r.Route("/api", func(r chi.Router) {
 		r.HandleFunc("/sys/get_env", proxy.HandleGetEnv)
 		r.HandleFunc("/statistics/get", statsGet)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -198,6 +198,7 @@ func CreateStriveProxy(listen string, GGStriveAPIURL string, PatchedAPIURL strin
 		r.HandleFunc("/sys/get_env", proxy.HandleGetEnv)
 		r.HandleFunc("/statistics/get", statsGet)
 		r.HandleFunc("/statistics/set", statsSet)
+		r.HandleFunc("/tus/write", statsSet)
 		r.HandleFunc("/sys/get_news", getNews)
 		r.HandleFunc("/catalog/get_follow", statsGet)
 		r.HandleFunc("/catalog/get_block", statsGet)


### PR DESCRIPTION
Sending a random request to the api endpoint when the proxy gets initialized saves about a second because the TLS stuff happens before GGST sends requests.

`/tus/write` behaves pretty similar to `/statistics/set/`. It sends a lot of data and has no response value. Using `statsSet` for this request saves about 4 seconds on the loading screen.

In total these changes reduce my loading time from 20s to 15s.