### PR TITLE
add new unsafe-predict-replay flag that prefetches 3 random replays

### DIFF
--- a/UNSAFE_SPEEDUPS.md
+++ b/UNSAFE_SPEEDUPS.md
@@ -72,3 +72,28 @@ GGST will display some default news instead of the latest ones.
 
 Since this returns a completely empty body, it might break the game in future versions. If that happens this would have to be expanded to return some skeleton news entries.  
 Right now GGST seems to handle the empty body gracefully.
+
+## `-unsafe-cache-env` ([@Borengar](https://github.com/Borengar))
+
+(v1.6.0+)
+
+Totsugeki returns a hard-coded response for `/api/sys/get_env` calls.
+
+This request gets called before every `/api/user/login` one. (Initial loading on title screen; replays; ranking; entering tower; etc).
+
+### Speedup
+
+Up to 1 second every time when you enter the tower, open replays, open the ranking list, etc.  
+2 seconds on the initial title screen loading if you start fast enough.
+
+## `-unsafe-predict-replay` ([@Borengar](https://github.com/Borengar))
+
+(v1.7.0+)
+
+Totsugeki prefetches random celestial floor replays for the loading screen `/api/catalog/get_replay` calls.
+
+The first batch of recommended replays will contain random replays when you open the replays dialog. A refresh will load actual replays that are recommended for you.
+
+### Speedup
+
+2-3 seconds saved on the initial loading on title screen.

--- a/main.go
+++ b/main.go
@@ -283,6 +283,7 @@ func main() {
 	var unsafePredictStatsGet = flag.Bool("unsafe-predict-stats-get", false, "UNSAFE: Asynchronously precache expected statistics/get calls.")
 	var unsafeCacheNews = flag.Bool("unsafe-cache-news", false, "UNSAFE: Cache first news call and return cached version on subsequent calls.")
 	var unsafeNoNews = flag.Bool("unsafe-no-news", false, "UNSAFE: Return an empty response for news.")
+	var unsafePredictReplay = flag.Bool("unsafe-predict-replay", false, "UNSAFE: Asynchronously precache expected get_replay calls. Needs unsafe-predict-stats-get to work.")
 	var ungaBunga = flag.Bool("unga-bunga", UngaBungaMode != "", "UNSAFE: Enable all unsafe speedups for maximum speed. Please read https://github.com/optix2000/totsugeki/blob/master/UNSAFE_SPEEDUPS.md")
 	var iKnowWhatImDoing = flag.Bool("i-know-what-im-doing", false, "UNSAFE: Suppress any UNSAFE warnings. I hope you know what you're doing...")
 	var ver = flag.Bool("version", false, "Print the version number and exit.")
@@ -323,6 +324,7 @@ func main() {
 		*unsafeAsyncStatsSet = true
 		*unsafePredictStatsGet = true
 		*unsafeNoNews = true
+		*unsafePredictReplay = true
 	}
 
 	// Drop process priority
@@ -399,6 +401,7 @@ func main() {
 				PredictStatsGet: *unsafePredictStatsGet,
 				CacheNews:       *unsafeCacheNews,
 				NoNews:          *unsafeNoNews,
+				PredictReplay:   *unsafePredictReplay,
 			})
 
 			fmt.Println("Started Proxy Server on port 21611.")
@@ -411,7 +414,7 @@ func main() {
 		}()
 	}
 
-	if !*iKnowWhatImDoing && (*unsafeAsyncStatsSet || *unsafePredictStatsGet || *unsafeCacheNews || *unsafeNoNews) {
+	if !*iKnowWhatImDoing && (*unsafeAsyncStatsSet || *unsafePredictStatsGet || *unsafeCacheNews || *unsafeNoNews || *unsafePredictReplay) {
 		fmt.Println("WARNING: Unsafe feature used. Make sure you understand the implications: https://github.com/optix2000/totsugeki/blob/master/UNSAFE_SPEEDUPS.md")
 	}
 


### PR DESCRIPTION
`get_replay` gets called 3 times on the loading screen. The returned replays are used as the recommended replays. Seems to be your main vs 3 random characters at roughly your floor level. Since the characters are random we can't predict the exact request body.
If we don't care about the recommended replays we could instead prefetch 3 random replays and return those, which saves about 1.5 seconds. Actual recommended replays can still be loaded by using the reload button in the replays dialog.

This would add a new `unsafe-predict-replay` flag which prefetches 3 replays with random characters on celestial floor.