### PR TITLE
Update APIOffsetAddr for GGST v1.11

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ var UngaBungaMode string = ""
 
 const GGStriveExe = "GGST-Win64-Shipping.exe"
 
-const APIOffsetAddr uintptr = 0x33FC4A0 // 1.10
+const APIOffsetAddr uintptr = 0x342BBC0 // 1.11
 
 const GGStriveAPIURL = "https://ggst-game.guiltygear.com/api/"
 const PatchedAPIURL = "http://127.0.0.1:21611/api/"


### PR DESCRIPTION
Have been using 1.8.0 with the unsafe settings on w/o issue so I updated this.

Mostly did this to try go out a little bit but I hope it's a tiny bit helpful!