### PR TITLE
Update API url offset for version 1.16

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ var UngaBungaMode string = ""
 
 const GGStriveExe = "GGST-Win64-Shipping.exe"
 
-const APIOffsetAddr uintptr = 0x33FC4A0 // 1.10
+const APIOffsetAddr uintptr = 0x34D23F8 // 1.16
 
 const GGStriveAPIURL = "https://ggst-game.guiltygear.com/api/"
 const PatchedAPIURL = "http://127.0.0.1:21611/api/"


### PR DESCRIPTION
This should be the new correct offset for version 1.16.